### PR TITLE
fix bug: permission latency(temp)

### DIFF
--- a/tui/agent-binding.ts
+++ b/tui/agent-binding.ts
@@ -222,7 +222,6 @@ function setupCallbacks(orchestrator: AgentOrchestrator) {
       setTimeout(() => scrollToBottom(), 100)
 
       permissionResolver = (decision, reason) => {
-        resolve(decision)
         appState.agentState.pendingPermission = null
         appState.agentState.isProcessing = decision !== PermissionDecision.DENY
 
@@ -237,6 +236,7 @@ function setupCallbacks(orchestrator: AgentOrchestrator) {
         appState.agentState.messages.push(resolutionMsg)
         triggerRebuild()
         setTimeout(() => scrollToBottom(), 100)
+        setTimeout(() => resolve(decision), 0)
       }
     })
   })

--- a/tui/chat-screen.ts
+++ b/tui/chat-screen.ts
@@ -23,6 +23,7 @@ import { setScrollBoxElement } from "./keyboard"
 
 let chatInputElement: InputRenderable | null = null
 let scrollBoxElement: ScrollBoxRenderable | null = null
+let boundChatInputElement: InputRenderable | null = null
 
 /**
  * Create the chat screen
@@ -42,12 +43,15 @@ export function createChatScreen(contentRoot: RootRenderable | BoxRenderable | n
       chatInputElement = input
       input.focus()
 
-      input.on(InputRenderableEvents.ENTER, (value: string) => {
-        if (value.trim() && !appState.agentState.isProcessing && appState.orchestrator) {
-          processUserInput(value.trim())
-          input.value = ""
-        }
-      })
+      if (input !== boundChatInputElement) {
+        boundChatInputElement = input
+        input.on(InputRenderableEvents.ENTER, (value: string) => {
+          if (value.trim() && !appState.agentState.isProcessing && appState.orchestrator) {
+            processUserInput(value.trim())
+            input.value = ""
+          }
+        })
+      }
     }
 
     const scrollBox = contentRoot.findDescendantById("chat-scrollbox") as ScrollBoxRenderable | null
@@ -132,7 +136,7 @@ function createChatInputArea(theme: Theme): VNode {
         id: "chat-input",
         width: "100%",
         textColor: theme.text,
-        placeholder: ">" + hasPermission ? "Use ↑↓ to select option, enter to confirm" : processing ? "Working..." : "Type a Message or / Command",
+        placeholder: hasPermission ? "Use arrows to select option, enter to confirm" : processing ? "Working..." : "Type a Message or / Command",
       })
     )
   )

--- a/tui/keyboard.ts
+++ b/tui/keyboard.ts
@@ -12,8 +12,7 @@ import {
 } from "./prompt-screen"
 import { closeOverlay, getOverlayElements } from "./overlays"
 import { closeCommandPalette, getCommandPaletteElements, openCommandPalette } from "./command-palette"
-import { getPermissionResolver } from "./agent-binding"
-import { PermissionDecision } from "../src/types/permissions"
+import { handlePermissionResponse } from "./agent-binding"
 
 let renderer: CliRenderer | null = null
 let scrollBoxElement: any = null
@@ -152,7 +151,6 @@ function handleChatKeys(key: KeyEvent) {
   // Permission inline navigation (highest priority)
   if (appState.agentState.pendingPermission) {
     const permission = appState.agentState.pendingPermission
-    const resolver = getPermissionResolver()
 
     if (key.name === "up" || key.name === "k") {
       if (permission.selectedIndex > 0) {
@@ -170,31 +168,13 @@ function handleChatKeys(key: KeyEvent) {
     }
     if (key.name === "return" || key.name === "enter") {
       const selected = permission.options[permission.selectedIndex]
-      if (selected && resolver) {
-        // Call the permission resolver to continue the agent loop
-        switch (selected.type) {
-          case "allow_once":
-            resolver(PermissionDecision.ALLOW, "Allowed once")
-            break
-          case "allow_session":
-            resolver(PermissionDecision.ALLOW, "Allowed for session")
-            break
-          case "custom":
-            // For custom, we deny and let the user type a custom message
-            appState.agentState.pendingPermission = null
-            triggerRebuild()
-            break
-        }
+      if (selected) {
+        handlePermissionResponse({ type: selected.type })
       }
       return
     }
     if (key.name === "escape") {
-      if (resolver) {
-        resolver(PermissionDecision.DENY, "Cancelled by user")
-      } else {
-        appState.agentState.pendingPermission = null
-        triggerRebuild()
-      }
+      handlePermissionResponse({ type: "deny" })
       return
     }
     // Also handle number keys 1-9 for quick selection
@@ -203,19 +183,8 @@ function handleChatKeys(key: KeyEvent) {
       if (idx < permission.options.length) {
         permission.selectedIndex = idx
         const selected = permission.options[idx]
-        if (selected && resolver) {
-          switch (selected.type) {
-            case "allow_once":
-              resolver(PermissionDecision.ALLOW, "Allowed once")
-              break
-            case "allow_session":
-              resolver(PermissionDecision.ALLOW, "Allowed for session")
-              break
-            case "custom":
-              appState.agentState.pendingPermission = null
-              triggerRebuild()
-              break
-          }
+        if (selected) {
+          handlePermissionResponse({ type: selected.type })
         }
       }
       return

--- a/tui/state.ts
+++ b/tui/state.ts
@@ -85,15 +85,20 @@ export const appState = {
 
 // State update callback
 let onStateChange: (() => void) | null = null
+let rebuildScheduled = false
 
 export function setStateChangeCallback(cb: () => void) {
   onStateChange = cb
 }
 
 export function triggerRebuild() {
-  if (onStateChange) {
-    onStateChange()
-  }
+  if (!onStateChange || rebuildScheduled) return
+
+  rebuildScheduled = true
+  setTimeout(() => {
+    rebuildScheduled = false
+    onStateChange?.()
+  }, 0)
 }
 
 // Helper to update state and trigger rebuild


### PR DESCRIPTION
temporary fix:
 - Batched triggerRebuild() so multiple state changes in the same tick collapse into one render: ```tui/state.ts```                               
  - Made keyboard approval use the single canonical permission handler instead of  directly resolving: ```tui/keyboard.ts```                         
  - Deferred permission resolution by one tick so the TUI can paint the approval/denial state before the tool resumes: ```tui/agent-binding.ts``` 
  - Guarded chat input ENTER binding so rebuilds do not keep attaching handlers: ```tui/chat-screen.ts```                                           
  - Fixed the chat placeholder precedence bug that made the permission placeholder logic wrong: ```tui/chat-screen.ts```

This is the temporary fix but once to reach production, merge current discuss further approaches or start working on a definitive long term resolution.